### PR TITLE
feat: Add agent support to chats

### DIFF
--- a/app/Http/Requests/StoreChatRequest.php
+++ b/app/Http/Requests/StoreChatRequest.php
@@ -21,6 +21,7 @@ class StoreChatRequest extends FormRequest
         return [
             'message' => ['required', 'string', 'max:10000'],
             'ai_model_id' => ['required', 'integer', 'exists:ai_models,id'],
+            'agent_id' => ['nullable', 'integer', 'exists:agents,id'],
         ];
     }
 }

--- a/app/Http/Requests/UpdateChatRequest.php
+++ b/app/Http/Requests/UpdateChatRequest.php
@@ -27,6 +27,7 @@ class UpdateChatRequest extends FormRequest
         return [
             'ai_model_id' => ['sometimes', 'integer', 'exists:ai_models,id'],
             'title' => ['sometimes', 'string', 'max:255'],
+            'agent_id' => ['sometimes', 'nullable', 'integer', 'exists:agents,id'],
         ];
     }
 }

--- a/resources/js/types/chat.ts
+++ b/resources/js/types/chat.ts
@@ -28,7 +28,7 @@ export enum ArtifactType {
 }
 
 export interface Artifact {
-    id: string;
+    id: number;
     message_id: string;
     identifier: string;
     type: ArtifactType;
@@ -51,23 +51,53 @@ export interface Message {
 }
 
 export interface Chat {
-    id: string;
+    id: number;
     user_id: number;
     title: string;
     ai_model_id: number;
-    ai_model?: Model;
+    ai_model?: AiModel;
+    agent_id?: number | null;
+    agent?: Agent | null;
     created_at: string;
     updated_at: string;
     messages?: Message[];
 }
 
-export interface Model {
+export interface AiModel {
     id: number;
     name: string;
-    model_id: string;
-    description: string | null;
-    provider?: string;
-    supports_tools?: boolean;
-    supports_vision?: boolean;
-    enabled?: boolean;
+    description: string;
+    provider: string;
+    model_id: string;    supports_tools: boolean;
+    supports_vision: boolean;
+    context_window: number;
+    speed_tier: string;
+    cost_tier: string;}
+
+export interface Agent {
+    id: number;
+    name: string;
+    description: string;
+    user_id: number | null;
+    default_model_id: number | null;
+    system_prompt: string | null;
+    avatar: string | null;
+    tools: string[] | null;
+    capabilities: string[] | null;
+    is_active: boolean;
+    created_at: string;
+    updated_at: string;
+    default_model?: AiModel;
+}
+
+export interface ToolOption {
+    id: number;
+    name: string;
+    description: string;
+}
+
+export interface CapabilityOption {
+    id: number;
+    name: string;
+    description: string;
 }


### PR DESCRIPTION
## Summary
- Allow chats to be associated with agents for specialized interactions

## Changes
- Add `agent_id` validation to `StoreChatRequest` and `UpdateChatRequest`
- Update TypeScript types:
  - Add `Agent` interface with full type definitions
  - Update `AiModel` interface with provider and capability fields
  - Add `ToolOption` and `CapabilityOption` types
  - Update `Chat` interface with agent relationship

## Test Plan
- [ ] Verify chat creation with agent_id works
- [ ] Verify chat update with agent_id works
- [ ] Verify TypeScript types compile correctly